### PR TITLE
This PR updates the DQ Robotics toolbox installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ All lessons are in MATLAB Live Script format, meaning that the coding is explain
 ## How to use
 
 1. Install [MATLAB](https://www.mathworks.com/products/matlab.html).
-2. Install the most recent Matlab toolbox of DQ Robotics. See our [website](https://dqrobotics.github.io/) for installation instructions.
+2. Install the most recent Matlab toolbox of [DQ Robotics](https://github.com/dqrobotics/matlab/releases/latest). See our [website](https://dqrobotics.github.io/) for installation instructions.
 3. Clone this repository or [download it as a ZIP package](https://github.com/dqrobotics/learning-dqrobotics-with-coppeliasim/archive/refs/heads/main.zip).
 4. Install [CoppeliaSim](https://www.coppeliarobotics.com/).
 5. Download the [CoppeliaSim scenes](https://osf.io/2tfsx/) (the .ttt files) used in the lessons.

--- a/README.md
+++ b/README.md
@@ -7,14 +7,12 @@ All lessons are in MATLAB Live Script format, meaning that the coding is explain
 ## How to use
 
 1. Install [MATLAB](https://www.mathworks.com/products/matlab.html).
-2. Clone the latest version of the [DQ Robotics](https://github.com/dqrobotics/matlab) or [download it as a ZIP package](https://github.com/dqrobotics/matlab/archive/refs/heads/master.zip).
-2. Add it to the MATLAB path.
-   * Set Path > Add with Subfolders.
-4. Clone this repository or [download it as a ZIP package](https://github.com/dqrobotics/learning-dqrobotics-with-coppeliasim/archive/refs/heads/main.zip).
-5. Install [CoppeliaSim](https://www.coppeliarobotics.com/).
-6. Download the [CoppeliaSim scenes](https://osf.io/2tfsx/) (the .ttt files) used in the lessons.
+2. Install the most recent Matlab toolbox of DQ Robotics. See our [website](https://dqrobotics.github.io/) for installation instructions.
+3. Clone this repository or [download it as a ZIP package](https://github.com/dqrobotics/learning-dqrobotics-with-coppeliasim/archive/refs/heads/main.zip).
+4. Install [CoppeliaSim](https://www.coppeliarobotics.com/).
+5. Download the [CoppeliaSim scenes](https://osf.io/2tfsx/) (the .ttt files) used in the lessons.
    * Or simply run: `curl https://files.de-1.osf.io/v1/resources/2tfsx/providers/osfstorage/?zip= -o scenes.zip`
-7. Open each lesson in MATLAB and follow through the live script.
+6. Open each lesson in MATLAB and follow through the live script.
 
 ## Lessons
 The following lessons are currently available.


### PR DESCRIPTION
Hi @dqrobotics/developers,

This PR updates the installation instructions of the DQ Robotics MATLAB toolbox. Namely, it updates the requirements for its release version, as we discussed [here](https://github.com/dqrobotics/learning-dqrobotics-with-coppeliasim/pull/3#issuecomment-3237162556). I've tested the tutorials, and they are working fine with this version.

Kind regards,
Frederico